### PR TITLE
Fixed a bug causing future release dates to be converted incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ Which game properties should be fetched when a new Steam game is detected, and t
 	"gameIcon": true,
 	"releaseDate": {
 		"enabled": true,
-		"notionProperty": "Release Date",
-		"format": "date"
+		"notionProperty": "Release Date"
 	},
 	"reviewScore": {
 		"enabled": true,
@@ -277,8 +276,7 @@ The release date of the game. The database field in Notion must be of type "Date
 ```json
 "releaseDate": {
 	"enabled": true,
-	"notionProperty": "Release Date",
-	"format": "date"
+	"notionProperty": "Release Date"
 }
 ```
 
@@ -299,14 +297,6 @@ The name of the Notion property to set the release date in.
 | Type | Default value | Possible values | Required |
 |---|---|---|---|
 | `string` | `"Release Date"` | A valid Notion property name | Yes |
-
-<h4><code>format</code></h4>
-
-The format in which the release date should be set in the database. Can be either "date" or "datetime".
-
-| Type | Default value | Possible values | Required |
-|---|---|---|---|
-| `string` | `"date"` | `"date"` or `"datetime"` | Yes |
 </details>
 
 <details>

--- a/config.default.json
+++ b/config.default.json
@@ -22,8 +22,7 @@
 		},
 		"releaseDate": {
 			"enabled": true,
-			"notionProperty": "Release Date",
-			"format": "date"
+			"notionProperty": "Release Date"
 		},
 		"reviewScore": {
 			"enabled": true,

--- a/config.schema.json
+++ b/config.schema.json
@@ -60,8 +60,7 @@
 				},
 				"releaseDate": {
 					"enabled": true,
-					"notionProperty": "Release Date",
-					"format": "date"
+					"notionProperty": "Release Date"
 				},
 				"reviewScore": {
 					"enabled": true,
@@ -179,8 +178,7 @@
 					"type": "object",
 					"default": {
 						"enabled": true,
-						"notionProperty": "Release Date",
-						"format": "date"
+						"notionProperty": "Release Date"
 					},
 					"additionalProperties": false,
 					"properties": {
@@ -193,21 +191,11 @@
 							"description": "The name of the Notion property to set the release date in.",
 							"type": "string",
 							"default": "Release Date"
-						},
-						"format": {
-							"description": "The format in which the release date should be set in the database. Can be either \"date\" or \"datetime\".",
-							"type": "string",
-							"default": "date",
-							"enum": [
-								"date",
-								"datetime"
-							]
 						}
 					},
 					"required": [
 						"enabled",
-						"notionProperty",
-						"format"
+						"notionProperty"
 					]
 				},
 				"reviewScore": {

--- a/js/gameProperties.js
+++ b/js/gameProperties.js
@@ -117,16 +117,21 @@ function getGameReleaseDate(releaseDateProperty, appInfoDirect, outputProperties
 		// We need to distinguish three cases: Only the year is given ('2023'), year and month ('March 2023'), or year, month and day ('13 Mar, 2023')
 		// In cases where data is missing, we add the last day of the year or the first day of the month (as the last day of the month differs between months)
 		// We always add 00:00 UTC as the time, as the date is always given in UTC and we don't want to convert it to the local timezone
-		const dateSpecificity = appInfoDirect.release_date.date.split(" ").length;
-		if (dateSpecificity == 1) {
-			releaseDate = new Date(appInfoDirect.release_date.date + '-12-31 00:00 UTC').toISOString();
-		} else if (dateSpecificity == 2) {
-			releaseDate = new Date(appInfoDirect.release_date.date + '-01 00:00 UTC').toISOString();
-		} else if (dateSpecificity == 3) {
-			releaseDate = new Date(appInfoDirect.release_date.date + ' 00:00 UTC').toISOString();
-		} else {
-			console.warn('!!!The release date format received from the Steam store API is unknown to the integration.\n!!!Please report this to the developer and include the following output:');
-			console.log(appInfoDirect);
+		// We wrap this in a try-catch block as developers can set things other than dates, such as 'To be announced', which will raise an error during conversion
+		try {
+			const dateSpecificity = appInfoDirect.release_date.date.split(" ").length;
+			if (dateSpecificity == 1) {
+				releaseDate = new Date(appInfoDirect.release_date.date + '-12-31 00:00 UTC').toISOString();
+			} else if (dateSpecificity == 2) {
+				releaseDate = new Date(appInfoDirect.release_date.date + '-01 00:00 UTC').toISOString();
+			} else if (dateSpecificity == 3) {
+				releaseDate = new Date(appInfoDirect.release_date.date + ' 00:00 UTC').toISOString();
+			} else {
+				console.warn('!!!The release date format received from the Steam store API is unknown to the integration.\n!!!Please report this to the developer and include the following output:');
+				console.log(appInfoDirect);
+				return outputProperties;
+			}
+		} catch (error) {
 			return outputProperties;
 		}
 	} else {

--- a/js/gameProperties.js
+++ b/js/gameProperties.js
@@ -133,9 +133,8 @@ function getGameReleaseDate(releaseDateProperty, appInfoDirect, outputProperties
 		return outputProperties;
 	}
 
-	if (releaseDate && releaseDateProperty.format == "date") {
-		releaseDate = releaseDate.split("T")[0];
-	}
+	// We only want the date, not the time, as the store API doesn't provide the time
+	releaseDate = releaseDate.split("T")[0];
 
 	outputProperties[releaseDateProperty.notionProperty] = {
 		"date": {

--- a/js/utils.js
+++ b/js/utils.js
@@ -82,6 +82,7 @@ export async function addGameToLocalDatabase(pageId, steamAppId) {
 function isStoreAPIRequired() {
 	return (
 		CONFIG.gameProperties.coverImage?.enabled ||
+		CONFIG.gameProperties.releaseDate?.enabled ||
 		CONFIG.gameProperties.gameDescription?.enabled ||
 		CONFIG.gameProperties.gamePrice?.enabled
 	)
@@ -90,7 +91,6 @@ function isStoreAPIRequired() {
 function isSteamUserAPIRequired() {
 	return (
 		CONFIG.gameProperties.gameName?.enabled ||
-		CONFIG.gameProperties.releaseDate?.enabled ||
 		CONFIG.gameProperties.reviewScore?.enabled ||
 		CONFIG.gameProperties.tags?.enabled ||
 		CONFIG.gameProperties.gameIcon?.enabled ||

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "notion-steam-api-integration",
 	"type": "module",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "Notion integration to fetch data from the Steam API and populate a databse given Steam App ID's.",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
As a result of this bugfix, the "format" option of the "releaseDate" configuration property has been removed, as it is no longer needed.