### PR TITLE
Fixed tag fetching, now requires Steam login

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ The schema can be found in the `config.schema.json` file and used within your `c
 
 *NOTE: The script will test your provided `config.json` against this schema, so make sure your configuration is valid.*
 
+Note that *only if* you want to fetch tag data, Steam requires you to be authenticated with your Steam account.
+For this, provide your Steam account name and password in the `steamUser` property of the configuration file.
+The integration does not transmit this data over the internet, everything is done locally.
+If you have Steam Guard enabled, you will also need to provide the Steam Guard code when running the integration.
+
+Once you have authenticated once, the integration will store a local refresh token for ~200 days before you need to log in again.
+You can then replace the `accountName` and `password` with the `useRefreshToken` property set to `true`, which will make the integration use the stored refresh token to authenticate you to the Steam API.
+
 ### Properties
 
 The following is a list of all configuration items, their defaults and the values they can take.
@@ -115,6 +123,18 @@ If true, the integration will always update entries in the Notion database that 
 </details>
 
 <details>
+<summary><code>steamUser</code></summary>
+
+Login details to authenticate to your Steam account. This is required to be able to fetch tag data. If you have Steam Guard enabled, you will need to provide the Steam Guard code when running the app. Once logged in, the integration will store a local refresh token for ~200 days before you need to log in again. The integration does not transmit any of your login details anywhere, they are used internally to authenticate yourself to the Steam API. If you do not want to fetch tag data, you do not need to provide this property!
+
+| Type | Default value | Possible values | Required |
+|---|---|---|---|
+| `useRefreshToken` | `true` | `true` only | Yes, if you want to use an already stored refresh token. This requires a previous login using `accountName` and `password`. |
+| `accountName` | `<steamAccountName>` | Your Steam account name | Yes, if you do not already have a stored refresh token and set `useRefreshToken` to `true`. |
+| `password` | `<steamAccountPassword>` | Your Steam account password | Yes, if you do not already have a stored refresh token and set `useRefreshToken` to `true`. |
+</details>
+
+<details>
 <summary><code>gameProperties</code></summary>
 
 Which game properties should be fetched when a new Steam game is detected, and the name of the corresponding field in the Notion database.
@@ -143,7 +163,8 @@ Which game properties should be fetched when a new Steam game is detected, and t
 	},
 	"tags": {
 		"enabled": true,
-		"notionProperty": "Tags"
+		"notionProperty": "Tags",
+		"tagLanguage": "english"
 	}
 }
 ```
@@ -347,7 +368,7 @@ The name of the Notion property to set the user review score in.
 <details>
 <summary><code>tags</code></summary>
 
-The user-defined tags of the game as they can be seen on the store page. The database field in Notion must be of type `Multi-select`.
+Requires Steam login! Provide accountName and password in the top-level `steamUser` property! The user-defined tags of the game as they can be seen on the store page. The database field in Notion must be of type `Multi-select`.
 
 | Type | Default value | Possible values | Required |
 |---|---|---|---|
@@ -357,7 +378,7 @@ The user-defined tags of the game as they can be seen on the store page. The dat
 "tags": {
 	"enabled": true,
 	"notionProperty": "Tags",
-	"language": "english"
+	"tagLanguage": "english"
 }
 ```
 
@@ -379,13 +400,13 @@ The name of the Notion property to set the tags in. This field must be of type `
 |---|---|---|---|
 | `string` | `"Tags"` | A valid Notion property name | Yes |
 
-<h4><code>language</code></h4>
+<h4><code>tagLanguage</code></h4>
 
 The language of the tags, e.g. "english" or "spanish".
 
 | Type | Default value | Possible values | Required |
 |---|---|---|---|
-| `string` | `"english"` | Valid language names. Invalid names return an error from the Steam API. | Yes |
+| `string` | `"english"` | Valid full language names. Invalid names return an error from the Steam API. | Yes |
 
 </details>
 

--- a/config.default.json
+++ b/config.default.json
@@ -6,6 +6,10 @@
 	"steamAppIdProperty": "Steam App ID",
 	"forceReset": false,
 	"alwaysUpdate": false,
+	"steamUser": {
+		"accountName": "<steamAccountName>",
+		"password": "<steamPassword>"
+	},
 	"gameProperties": {
 		"gameName": {
 			"enabled": true,

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,6 +41,50 @@
 			"type": "boolean",
 			"default": false
 		},
+		"steamUser": {
+			"description": "Login details to authenticate to your Steam account. This is required to be able to fetch tag data. If you have Steam Guard enabled, you will need to provide the Steam Guard code when running the app. Once logged in, the integration will store a local refresh token for ~200 days before you need to log in again. The integration does not transmit any of your login details anywhere, they are used internally to authenticate yourself to the Steam API. If you do not want to fetch tag data, you do not need to provide this property!",
+			"type": "object",
+			"default": {
+				"accountName": "<steamAccountName>",
+				"password": "<steamAccountPassword>"
+			},
+			"additionalProperties": false,
+			"properties": {
+				"useRefreshToken": {
+					"description": "If true, the integration will try to use the refresh token stored in the local database to authenticate to your Steam account. You can only set this to \"true\" if you have previously logged in using \"accountName\" and \"password\", and the refresh token is still valid.",
+					"type": "boolean",
+					"default": false
+				},
+				"accountName": {
+					"description": "Your Steam account name.",
+					"type": "string",
+					"default": "<steamAccountName>"
+				},
+				"password": {
+					"description": "Your Steam account password.",
+					"type": "string",
+					"default": "<steamAccountPassword>"
+				}
+			},
+			"oneOf": [
+				{
+					"required": [
+						"accountName",
+						"password"
+					]
+				},
+				{
+					"properties": {
+						"useRefreshToken": {
+							"const": true
+						}
+					},
+					"required": [
+						"useRefreshToken"
+					]
+				}
+			]
+		},
 		"gameProperties": {
 			"description": "Which game properties should be fetched when a new Steam game is detected, and the name of the corresponding field in the Notion database.",
 			"type": "object",
@@ -69,7 +113,8 @@
 				},
 				"tags": {
 					"enabled": true,
-					"notionProperty": "Tags"
+					"notionProperty": "Tags",
+					"tagLanguage": "english"
 				},
 				"gameDescription": {
 					"enabled": true,
@@ -227,30 +272,30 @@
 							"type": "string",
 							"default": "percentage",
 							"oneOf": [
-									{
-										"const": "percentage",
-										"title": "Notion database field type: \"Number\". A percentage value formatted as a float from 0.00-1.00."
-									},
-									{
-										"const": "sentiment",
-										"title": "Notion database field type: \"Select\". A sentiment value such as \"Overwhelmingly Positive\" or \"Mixed\"."
-									},
-									{
-										"const": "total",
-										"title": "Notion database field type: \"Number\". The total number of reviews submitted for the game, across all languages."
-									},
-									{
-										"const": "positive",
-										"title": "Notion database field type: \"Number\". The total number of positive reviews submitted for the game, across all languages."
-									},
-									{
-										"const": "negative",
-										"title": "Notion database field type: \"Number\". The total number of negative reviews submitted for the game, across all languages."
-									},
-									{
-										"const": "positive/negative",
-										"title": "Notion database field type: \"Text\". The total number of positive and negative reviews submitted for the game, across all languages, formatted as \"{numPositive} positive / {numNegative} negative\"."
-									}
+								{
+									"const": "percentage",
+									"title": "Notion database field type: \"Number\". A percentage value formatted as a float from 0.00-1.00."
+								},
+								{
+									"const": "sentiment",
+									"title": "Notion database field type: \"Select\". A sentiment value such as \"Overwhelmingly Positive\" or \"Mixed\"."
+								},
+								{
+									"const": "total",
+									"title": "Notion database field type: \"Number\". The total number of reviews submitted for the game, across all languages."
+								},
+								{
+									"const": "positive",
+									"title": "Notion database field type: \"Number\". The total number of positive reviews submitted for the game, across all languages."
+								},
+								{
+									"const": "negative",
+									"title": "Notion database field type: \"Number\". The total number of negative reviews submitted for the game, across all languages."
+								},
+								{
+									"const": "positive/negative",
+									"title": "Notion database field type: \"Text\". The total number of positive and negative reviews submitted for the game, across all languages, formatted as \"{numPositive} positive / {numNegative} negative\"."
+								}
 							]
 						},
 						"notionProperty": {
@@ -266,7 +311,7 @@
 					]
 				},
 				"tags": {
-					"description": "The user-defined tags of the game as they can be seen on the store page. The database field in Notion must be of type \"Multi-select\".",
+					"description": "Requires Steam login! Provide \"accountName\" and \"password\" in the top-level \"steamUser\" property, \"refreshToken\" if you already logged in before! The user-defined tags of the game as they can be seen on the store page. The database field in Notion must be of type \"Multi-select\".",
 					"type": "object",
 					"default": {
 						"enabled": true,
@@ -456,5 +501,29 @@
 		"updateInterval",
 		"steamAppIdProperty",
 		"gameProperties"
+	],
+	"allOf": [
+		{
+			"if": {
+				"properties": {
+					"gameProperties": {
+						"properties": {
+							"tags": {
+								"properties": {
+									"enabled": {
+										"const": true
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"then": {
+				"required": [
+					"steamUser"
+				]
+			}
+		}
 	]
 }

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ async function updateNotionDatabase() {
 				// Get info about the game's review score from the reviews API, if required
 				const appInfoReviews = reviewAPIRequired
 					? await getSteamReviewScoreDirect(steamAppId)
-					: null; 
+					: null;
 
 				let notionProperties = await getGameProperties(appInfoDirect, appInfoSteamUser[steamAppId], appInfoReviews, steamAppId);
 
@@ -106,7 +106,7 @@ async function updateNotionDatabase() {
 			}
 		}
 	}
-	
+
 	// Only update the last updated time if there were no errors during execution and we didn't hit the Steam API request limit
 	// This makes sure that we can find the games that had errors or that we had to omit again the next time
 	if (!hadError && !hitSteamAPILimit) {

--- a/js/steamAPI.js
+++ b/js/steamAPI.js
@@ -1,9 +1,40 @@
 import SteamUser from 'steam-user';
+import { CONFIG, addRefreshTokenToLocalDatabase, getRefreshTokenFromLocalDatabase, steamUserLoginRequired } from './utils.js';
 
 // ---------- Steam API ----------
 
-let steamClient = new SteamUser();
-steamClient.logOn();
+let steamUserConfig = {};
+
+if (steamUserLoginRequired) {
+	let refreshToken = await getRefreshTokenFromLocalDatabase();
+	if (refreshToken) {
+		steamUserConfig = {
+			refreshToken: refreshToken,
+		};
+	} else
+	if (CONFIG.steamUser.accountName && CONFIG.steamUser.password) {
+		steamUserConfig = {
+			accountName: CONFIG.steamUser.accountName,
+			password: CONFIG.steamUser.password,
+		}
+	} else {
+		console.error("\"steamUser.useRefreshToken\" was provided in the config, but no refresh token found in local database. \"steamUser.accountName\" and \"steamUser.password\" are required in the config, but they were not provided!");
+		process.exit(1);
+	}
+} else {
+	steamUserConfig = {
+		anonymous: true
+	};
+}
+
+let steamClient = new SteamUser({ renewRefreshTokens: true });
+
+steamClient.on('refreshToken', async function (refreshToken) {
+	await addRefreshTokenToLocalDatabase(refreshToken);
+});
+
+console.log("Logging in to Steam", steamUserConfig.anonymous ? "anonymously..." : (steamUserConfig.accountName ? `as ${steamUserConfig.accountName}...` : "using a refresh token..."));
+steamClient.logOn(steamUserConfig);
 await new Promise(resolve => steamClient.on('loggedOn', resolve));
 
 // Gets app info directly from the Steam store API
@@ -54,13 +85,13 @@ export async function getSteamAppInfoSteamUser(appIds) {
 // Gets the current review score data for a game from the Steam reviews API
 export async function getSteamReviewScoreDirect(appId) {
 	const result = await fetch(`https://store.steampowered.com/appreviews/${appId}?json=1&language=all`)
-	.then(response => response.json())
-	.then(data => {
-		if (data?.success) {
-			return data.query_summary;
-		}
-		return null;
-	});
+		.then(response => response.json())
+		.then(data => {
+			if (data?.success) {
+				return data.query_summary;
+			}
+			return null;
+		});
 
 	return result;
 }
@@ -77,10 +108,10 @@ export async function getSteamTagNames(storeTags, tagLanguage) {
 			const result = Object.keys(response.tags).map(function (key) {
 				return response.tags[key].name;
 			});
-	
+
 			resolve(result);
 		} catch (error) {
-			console.log("Retrieving tag names failed. The most likely cause is that the language you provided is invalid and does not yield any results from the Steam API.");
+			console.log("Retrieving tag names failed! The most likely cause is that you have not provided the \"steamUser\" property and are not authenticated, or the provided \"tagLanguage\" is invalid.");
 			resolve(["Retrieving tags failed"]);
 		}
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "notion-steam-api-integration",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "notion-steam-api-integration",
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"dependencies": {
 				"@notionhq/client": "^1.0.1",
 				"jsonschema": "^1.4.1",
 				"level": "^8.0.0",
-				"steam-user": "^4.26.1"
+				"steam-user": "^5.2.2"
 			}
 		},
 		"node_modules/@bbob/parser": {
@@ -39,6 +39,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
 			"integrity": "sha512-lsxgLw640gEdZBOXpVIcYWcYD+V+QbtEsMPzRvjmjz2XXKc7QeEMyHL07yOFRmay+cUwO4ObKTJO0dSInEuq5g=="
+		},
+		"node_modules/@doctormckay/user-agents": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@doctormckay/user-agents/-/user-agents-1.0.0.tgz",
+			"integrity": "sha512-F+sL1YmebZTY2CnjoR9BXFEULpq7y8dxyLx48LZVa0BSDseXdLG/DtPISfM1iNv1XKCeiBzVNfAT/MOQ69v1Zw==",
+			"license": "MIT"
 		},
 		"node_modules/@notionhq/client": {
 			"version": "1.0.4",
@@ -143,11 +149,12 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.4.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-			"integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=0.3.0"
+				"node": ">=12.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -161,27 +168,10 @@
 				"node": ">= 6.0.0"
 			}
 		},
-		"node_modules/appdirectory": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
-			"integrity": "sha512-DJ5DV8vZXBbusyiyPlH28xppwS8eAMRuuyMo88xeEcf4bV64lbLtbxRxqixZuJBXsZzLtXFmA13GwVjJc7vdQw==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
-		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -266,18 +256,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/catering": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
@@ -353,14 +331,6 @@
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dependencies": {
-				"is-callable": "^1.1.3"
-			}
-		},
 		"node_modules/form-data": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -372,71 +342,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"dependencies": {
-				"has-symbols": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/ieee754": {
@@ -458,29 +363,17 @@
 				}
 			]
 		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/ip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
-		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
 			},
 			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/is-buffer": {
@@ -505,48 +398,11 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-generator-function": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"license": "MIT"
 		},
 		"node_modules/jsonschema": {
 			"version": "1.4.1",
@@ -554,6 +410,15 @@
 			"integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/kvparser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/kvparser/-/kvparser-1.0.2.tgz",
+			"integrity": "sha512-5P/5qpTAHjVYWqcI55B3yQwSY2FUrYYrJj5i65V1Wmg7/4W4OnBcaodaEvLyVuugeOnS+BAaKm9LbPazGJcRyA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/level": {
@@ -645,6 +510,14 @@
 			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
 			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
 		},
+		"node_modules/node-bignumber": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.2.tgz",
+			"integrity": "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/node-fetch": {
 			"version": "2.6.7",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -678,6 +551,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.7.tgz",
 			"integrity": "sha512-EUNi/RIsyJ1P1u9QHFwMOUWMYetqlE22ZgGbad7YP856WF4BFF0B7DuNy6vEGsgNNud6c/SkdWzkne71hH8MjA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "*"
 			},
@@ -714,6 +588,27 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
 			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -773,7 +668,8 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/smart-buffer": {
 			"version": "4.2.0",
@@ -785,15 +681,16 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+			"integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+			"license": "MIT",
 			"dependencies": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -810,6 +707,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/steam-appticket": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.1.tgz",
@@ -825,6 +728,78 @@
 				"node": ">=4.0.0"
 			}
 		},
+		"node_modules/steam-session": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/steam-session/-/steam-session-1.9.3.tgz",
+			"integrity": "sha512-leunJ8205CpEg/QW98S3LS+18qWHGb6wfe1oh2y4v/EChW0gq7Hd/buKb4R/TVh7VbFvb4taMUbwPvMkNaOPyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@doctormckay/stdlib": "^2.9.0",
+				"@doctormckay/user-agents": "^1.0.0",
+				"debug": "^4.3.4",
+				"kvparser": "^1.0.1",
+				"node-bignumber": "^1.2.2",
+				"protobufjs": "^7.1.0",
+				"socks-proxy-agent": "^7.0.0",
+				"steamid": "^2.0.0",
+				"tiny-typed-emitter": "^2.1.0",
+				"websocket13": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/steam-session/node_modules/@doctormckay/stdlib": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+			"integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+			"license": "MIT",
+			"dependencies": {
+				"psl": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/steam-session/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/steam-session/node_modules/protobufjs": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+			"integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/steam-session/node_modules/steamid": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+			"integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/steam-totp": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.2.tgz",
@@ -834,29 +809,82 @@
 			}
 		},
 		"node_modules/steam-user": {
-			"version": "4.26.1",
-			"resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.26.1.tgz",
-			"integrity": "sha512-DbXptjuhsaRH98LMmF0h3rqb+XlPmFCCmDnAPshIwp+U+5HMMTBOQZnpEqkmxxXBi/AADT7wtrYib4SDgyMx0Q==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/steam-user/-/steam-user-5.2.2.tgz",
+			"integrity": "sha512-Q8Swxt0f8P3Qb+8kYVjJu1dMBmsrTirobNrGOUTLikYomzcL5JswC9GUEMV0Bjq/YgMr5K0tizYDuAkgRB5p7w==",
+			"license": "MIT",
 			"dependencies": {
 				"@bbob/parser": "^2.2.0",
-				"@doctormckay/stdlib": "^1.11.1",
+				"@doctormckay/stdlib": "^2.9.1",
 				"@doctormckay/steam-crypto": "^1.2.0",
-				"adm-zip": "^0.4.13",
-				"appdirectory": "^0.1.0",
+				"adm-zip": "^0.5.10",
 				"binarykvparser": "^2.2.0",
 				"bytebuffer": "^5.0.0",
 				"file-manager": "^2.0.0",
+				"kvparser": "^1.0.1",
 				"lzma": "^2.3.2",
-				"protobufjs": "^6.8.8",
+				"protobufjs": "^7.2.4",
 				"socks-proxy-agent": "^7.0.0",
 				"steam-appticket": "^1.0.1",
+				"steam-session": "^1.8.0",
 				"steam-totp": "^2.0.1",
-				"steamid": "^1.1.0",
-				"vdf": "^0.0.2",
-				"websocket13": "^2.1.3"
+				"steamid": "^2.0.0",
+				"websocket13": "^4.0.0",
+				"zstddec": "^0.1.0"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/steam-user/node_modules/@doctormckay/stdlib": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+			"integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+			"license": "MIT",
+			"dependencies": {
+				"psl": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/steam-user/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/steam-user/node_modules/protobufjs": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+			"integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/steam-user/node_modules/steamid": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+			"integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/steamid": {
@@ -867,30 +895,16 @@
 				"cuint": "^0.2.1"
 			}
 		},
+		"node_modules/tiny-typed-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+			"integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+			"license": "MIT"
+		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
-		"node_modules/vdf": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/vdf/-/vdf-0.0.2.tgz",
-			"integrity": "sha512-iqFbR0zZeXQGaJzr7g8tFdQAgqIO3aTGoTLQGDugbiX4AZGdkbzSS/q9MXbvOSTfdP4TAEYZ124QWwLoueKvSw==",
-			"dependencies": {
-				"util": "*"
-			}
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
@@ -901,22 +915,37 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
 			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/websocket13": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.2.0.tgz",
-			"integrity": "sha512-m3aS0sLEM9dRM2+Cvgakdr/oLqyfAObdUlUqU3gdw3PuI81k1Hw3PWdwJsehvRRlScHolA13yYsx/X3OUzsTLA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/websocket13/-/websocket13-4.0.0.tgz",
+			"integrity": "sha512-/ujP9ZfihyAZIXKGxcYpoe7Gj4r5o3WYSfP93o9lVNhhqoBtYba4m1s3mxdjKZu/HOhX5Mcqrt89dv/gC3b06A==",
+			"license": "MIT",
 			"dependencies": {
-				"@doctormckay/stdlib": "^1.8.0",
+				"@doctormckay/stdlib": "^2.7.1",
 				"bytebuffer": "^5.0.1",
-				"permessage-deflate": "^0.1.6",
-				"websocket-extensions": "^0.1.2"
+				"permessage-deflate": "^0.1.7",
+				"tiny-typed-emitter": "^2.1.0",
+				"websocket-extensions": "^0.1.4"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/websocket13/node_modules/@doctormckay/stdlib": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+			"integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+			"license": "MIT",
+			"dependencies": {
+				"psl": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=12.22.0"
 			}
 		},
 		"node_modules/whatwg-url": {
@@ -928,24 +957,11 @@
 				"webidl-conversions": "^3.0.0"
 			}
 		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0",
-				"is-typed-array": "^1.1.10"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+		"node_modules/zstddec": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+			"integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+			"license": "MIT AND BSD-3-Clause"
 		}
 	},
 	"dependencies": {
@@ -971,6 +987,11 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
 			"integrity": "sha512-lsxgLw640gEdZBOXpVIcYWcYD+V+QbtEsMPzRvjmjz2XXKc7QeEMyHL07yOFRmay+cUwO4ObKTJO0dSInEuq5g=="
+		},
+		"@doctormckay/user-agents": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@doctormckay/user-agents/-/user-agents-1.0.0.tgz",
+			"integrity": "sha512-F+sL1YmebZTY2CnjoR9BXFEULpq7y8dxyLx48LZVa0BSDseXdLG/DtPISfM1iNv1XKCeiBzVNfAT/MOQ69v1Zw=="
 		},
 		"@notionhq/client": {
 			"version": "1.0.4",
@@ -1069,9 +1090,9 @@
 			}
 		},
 		"adm-zip": {
-			"version": "0.4.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-			"integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="
 		},
 		"agent-base": {
 			"version": "6.0.2",
@@ -1081,20 +1102,10 @@
 				"debug": "4"
 			}
 		},
-		"appdirectory": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
-			"integrity": "sha512-DJ5DV8vZXBbusyiyPlH28xppwS8eAMRuuyMo88xeEcf4bV64lbLtbxRxqixZuJBXsZzLtXFmA13GwVjJc7vdQw=="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
 		},
 		"base64-js": {
 			"version": "1.5.1",
@@ -1141,15 +1152,6 @@
 			"integrity": "sha512-IuzSdmADppkZ6DlpycMkm8l9zeEq16fWtLvunEwFiYciR/BHo4E8/xs5piFquG+Za8OWmMqHF8zuRviz2LHvRQ==",
 			"requires": {
 				"long": "~3"
-			}
-		},
-		"call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"catering": {
@@ -1203,14 +1205,6 @@
 				"@doctormckay/stdlib": "^1.14.1"
 			}
 		},
-		"for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"requires": {
-				"is-callable": "^1.1.3"
-			}
-		},
 		"form-data": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -1221,72 +1215,18 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.3"
-			}
-		},
-		"gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"requires": {
-				"get-intrinsic": "^1.1.3"
-			}
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-		},
-		"has-tostringtag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-			"requires": {
-				"has-symbols": "^1.0.2"
-			}
-		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
-		},
-		"is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+		"ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
 			"requires": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
 			}
 		},
 		"is-buffer": {
@@ -1294,35 +1234,20 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
 			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
 		},
-		"is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-		},
-		"is-generator-function": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-			"integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-			"requires": {
-				"has-tostringtag": "^1.0.0"
-			}
-		},
-		"is-typed-array": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
-			}
+		"jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
 		},
 		"jsonschema": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
 			"integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ=="
+		},
+		"kvparser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/kvparser/-/kvparser-1.0.2.tgz",
+			"integrity": "sha512-5P/5qpTAHjVYWqcI55B3yQwSY2FUrYYrJj5i65V1Wmg7/4W4OnBcaodaEvLyVuugeOnS+BAaKm9LbPazGJcRyA=="
 		},
 		"level": {
 			"version": "8.0.0",
@@ -1385,6 +1310,11 @@
 			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
 			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
 		},
+		"node-bignumber": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.2.tgz",
+			"integrity": "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ=="
+		},
 		"node-fetch": {
 			"version": "2.6.7",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -1433,6 +1363,19 @@
 				}
 			}
 		},
+		"psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"requires": {
+				"punycode": "^2.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+		},
 		"queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1457,11 +1400,11 @@
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
 		},
 		"socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+			"integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
 			"requires": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			}
 		},
@@ -1475,6 +1418,11 @@
 				"socks": "^2.6.2"
 			}
 		},
+		"sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+		},
 		"steam-appticket": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.1.tgz",
@@ -1487,32 +1435,128 @@
 				"steamid": "^1.1.0"
 			}
 		},
+		"steam-session": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/steam-session/-/steam-session-1.9.3.tgz",
+			"integrity": "sha512-leunJ8205CpEg/QW98S3LS+18qWHGb6wfe1oh2y4v/EChW0gq7Hd/buKb4R/TVh7VbFvb4taMUbwPvMkNaOPyg==",
+			"requires": {
+				"@doctormckay/stdlib": "^2.9.0",
+				"@doctormckay/user-agents": "^1.0.0",
+				"debug": "^4.3.4",
+				"kvparser": "^1.0.1",
+				"node-bignumber": "^1.2.2",
+				"protobufjs": "^7.1.0",
+				"socks-proxy-agent": "^7.0.0",
+				"steamid": "^2.0.0",
+				"tiny-typed-emitter": "^2.1.0",
+				"websocket13": "^4.0.0"
+			},
+			"dependencies": {
+				"@doctormckay/stdlib": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+					"integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+					"requires": {
+						"psl": "^1.9.0"
+					}
+				},
+				"long": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+					"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+				},
+				"protobufjs": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+					"integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+					"requires": {
+						"@protobufjs/aspromise": "^1.1.2",
+						"@protobufjs/base64": "^1.1.2",
+						"@protobufjs/codegen": "^2.0.4",
+						"@protobufjs/eventemitter": "^1.1.0",
+						"@protobufjs/fetch": "^1.1.0",
+						"@protobufjs/float": "^1.0.2",
+						"@protobufjs/inquire": "^1.1.0",
+						"@protobufjs/path": "^1.1.2",
+						"@protobufjs/pool": "^1.1.0",
+						"@protobufjs/utf8": "^1.1.0",
+						"@types/node": ">=13.7.0",
+						"long": "^5.0.0"
+					}
+				},
+				"steamid": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+					"integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg=="
+				}
+			}
+		},
 		"steam-totp": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.2.tgz",
 			"integrity": "sha512-bTKlc/NoIUQId+my+O556s55DDsNNXfVIPWFDNVu68beql7AJhV0c+GTjFxfwCDYfdc4NkAme+0WrDdnY2D2VA=="
 		},
 		"steam-user": {
-			"version": "4.26.1",
-			"resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.26.1.tgz",
-			"integrity": "sha512-DbXptjuhsaRH98LMmF0h3rqb+XlPmFCCmDnAPshIwp+U+5HMMTBOQZnpEqkmxxXBi/AADT7wtrYib4SDgyMx0Q==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/steam-user/-/steam-user-5.2.2.tgz",
+			"integrity": "sha512-Q8Swxt0f8P3Qb+8kYVjJu1dMBmsrTirobNrGOUTLikYomzcL5JswC9GUEMV0Bjq/YgMr5K0tizYDuAkgRB5p7w==",
 			"requires": {
 				"@bbob/parser": "^2.2.0",
-				"@doctormckay/stdlib": "^1.11.1",
+				"@doctormckay/stdlib": "^2.9.1",
 				"@doctormckay/steam-crypto": "^1.2.0",
-				"adm-zip": "^0.4.13",
-				"appdirectory": "^0.1.0",
+				"adm-zip": "^0.5.10",
 				"binarykvparser": "^2.2.0",
 				"bytebuffer": "^5.0.0",
 				"file-manager": "^2.0.0",
+				"kvparser": "^1.0.1",
 				"lzma": "^2.3.2",
-				"protobufjs": "^6.8.8",
+				"protobufjs": "^7.2.4",
 				"socks-proxy-agent": "^7.0.0",
 				"steam-appticket": "^1.0.1",
+				"steam-session": "^1.8.0",
 				"steam-totp": "^2.0.1",
-				"steamid": "^1.1.0",
-				"vdf": "^0.0.2",
-				"websocket13": "^2.1.3"
+				"steamid": "^2.0.0",
+				"websocket13": "^4.0.0",
+				"zstddec": "^0.1.0"
+			},
+			"dependencies": {
+				"@doctormckay/stdlib": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+					"integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+					"requires": {
+						"psl": "^1.9.0"
+					}
+				},
+				"long": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+					"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+				},
+				"protobufjs": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+					"integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+					"requires": {
+						"@protobufjs/aspromise": "^1.1.2",
+						"@protobufjs/base64": "^1.1.2",
+						"@protobufjs/codegen": "^2.0.4",
+						"@protobufjs/eventemitter": "^1.1.0",
+						"@protobufjs/fetch": "^1.1.0",
+						"@protobufjs/float": "^1.0.2",
+						"@protobufjs/inquire": "^1.1.0",
+						"@protobufjs/path": "^1.1.2",
+						"@protobufjs/pool": "^1.1.0",
+						"@protobufjs/utf8": "^1.1.0",
+						"@types/node": ">=13.7.0",
+						"long": "^5.0.0"
+					}
+				},
+				"steamid": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+					"integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg=="
+				}
 			}
 		},
 		"steamid": {
@@ -1523,30 +1567,15 @@
 				"cuint": "^0.2.1"
 			}
 		},
+		"tiny-typed-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+			"integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-		},
-		"util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
-		"vdf": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/vdf/-/vdf-0.0.2.tgz",
-			"integrity": "sha512-iqFbR0zZeXQGaJzr7g8tFdQAgqIO3aTGoTLQGDugbiX4AZGdkbzSS/q9MXbvOSTfdP4TAEYZ124QWwLoueKvSw==",
-			"requires": {
-				"util": "*"
-			}
 		},
 		"webidl-conversions": {
 			"version": "3.0.1",
@@ -1559,14 +1588,25 @@
 			"integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
 		},
 		"websocket13": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.2.0.tgz",
-			"integrity": "sha512-m3aS0sLEM9dRM2+Cvgakdr/oLqyfAObdUlUqU3gdw3PuI81k1Hw3PWdwJsehvRRlScHolA13yYsx/X3OUzsTLA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/websocket13/-/websocket13-4.0.0.tgz",
+			"integrity": "sha512-/ujP9ZfihyAZIXKGxcYpoe7Gj4r5o3WYSfP93o9lVNhhqoBtYba4m1s3mxdjKZu/HOhX5Mcqrt89dv/gC3b06A==",
 			"requires": {
-				"@doctormckay/stdlib": "^1.8.0",
+				"@doctormckay/stdlib": "^2.7.1",
 				"bytebuffer": "^5.0.1",
-				"permessage-deflate": "^0.1.6",
-				"websocket-extensions": "^0.1.2"
+				"permessage-deflate": "^0.1.7",
+				"tiny-typed-emitter": "^2.1.0",
+				"websocket-extensions": "^0.1.4"
+			},
+			"dependencies": {
+				"@doctormckay/stdlib": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+					"integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
+					"requires": {
+						"psl": "^1.9.0"
+					}
+				}
 			}
 		},
 		"whatwg-url": {
@@ -1578,18 +1618,10 @@
 				"webidl-conversions": "^3.0.0"
 			}
 		},
-		"which-typed-array": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0",
-				"is-typed-array": "^1.1.10"
-			}
+		"zstddec": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+			"integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "notion-steam-api-integration",
 	"type": "module",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"description": "Notion integration to fetch data from the Steam API and populate a database given Steam App ID's.",
 	"main": "index.js",
 	"dependencies": {
 		"@notionhq/client": "^1.0.1",
 		"jsonschema": "^1.4.1",
 		"level": "^8.0.0",
-		"steam-user": "^4.26.1"
+		"steam-user": "^5.2.2"
 	}
 }


### PR DESCRIPTION
The Steam API has changed to now require a login when fetching tags. If the tag property is provided in the config, the user now needs to provide the `steamUser` property with an account name and password. Once authenticated, the integration will store a refresh token locally instead of requiring additional logins in the future